### PR TITLE
Campaign and product configuration for stage/test and localhost

### DIFF
--- a/data/2016-02-04T14:00:00.000Z/environments.json
+++ b/data/2016-02-04T14:00:00.000Z/environments.json
@@ -59,7 +59,7 @@
       }
       }
     }
-  }
+  },
   "localhost": {
     "payment": {
       "externalHost": "http://localhost.aftonbladet.se:9000",

--- a/data/2016-02-04T14:00:00.000Z/environments.json
+++ b/data/2016-02-04T14:00:00.000Z/environments.json
@@ -10,43 +10,43 @@
           "months": 3,
           "price": 149,
           "unit": "kr/månad",
-          "productId": "200247",
-          "campaignId": "10020"
+          "productId": "10022",
+          "campaignId": "11"
         },
         "six-months-monthly": {
           "months": 6,
           "price": 129,
           "unit": "kr/månad",
-          "productId": "200249",
-          "campaignId": "10020"
+          "productId": "10022",
+          "campaignId": "11"
         },
         "twelve-months-monthly": {
           "months": 12,
           "price": 79,
           "unit": "kr/månad",
-          "productId": "200251",
-          "campaignId": "10020"
+          "productId": "10024",
+          "campaignId": "11"
         },
         "three-months-upfront": {
           "months": 3,
           "price": 447,
           "unit": "kr",
-          "productId": "200248",
-          "campaignId": "10051"
+          "productId": "10022",
+          "campaignId": "11"
         },
         "six-months-upfront": {
           "months": 6,
           "price": 774,
           "unit": "kr",
-          "productId": "200250",
-          "campaignId": "10051"
+          "productId": "10022",
+          "campaignId": "11"
         },
         "twelve-months-upfront": {
           "months": 12,
           "price": 948,
           "unit": "kr",
-          "productId": "200252",
-          "campaignId": "10051"
+          "productId": "10024",
+          "campaignId": "11"
         },
       "special-offer": {
         "months": 100,
@@ -54,8 +54,69 @@
         "unit": "kr",
         "offerLength": 6,
         "lengthUnit": "månader",
-        "productId": "203243",
-        "campaignId": "11036"
+        "productId": "10022",
+        "campaignId": "11"
+      }
+      }
+    }
+  }
+  "localhost": {
+    "payment": {
+      "externalHost": "http://localhost.aftonbladet.se:9000",
+      "path": "purchase",
+      "productQuery": "product_id",
+      "campaignQuery": "campaign_id",
+      "offers": {
+        "three-months-monthly": {
+          "months": 3,
+          "price": 149,
+          "unit": "kr/månad",
+          "productId": "10022",
+          "campaignId": "11"
+        },
+        "six-months-monthly": {
+          "months": 6,
+          "price": 129,
+          "unit": "kr/månad",
+          "productId": "10022",
+          "campaignId": "11"
+        },
+        "twelve-months-monthly": {
+          "months": 12,
+          "price": 79,
+          "unit": "kr/månad",
+          "productId": "10024",
+          "campaignId": "11"
+        },
+        "three-months-upfront": {
+          "months": 3,
+          "price": 447,
+          "unit": "kr",
+          "productId": "10022",
+          "campaignId": "11"
+        },
+        "six-months-upfront": {
+          "months": 6,
+          "price": 774,
+          "unit": "kr",
+          "productId": "10022",
+          "campaignId": "11"
+        },
+        "twelve-months-upfront": {
+          "months": 12,
+          "price": 948,
+          "unit": "kr",
+          "productId": "10024",
+          "campaignId": "11"
+        },
+      "special-offer": {
+        "months": 100,
+        "price": 398,
+        "unit": "kr",
+        "offerLength": 6,
+        "lengthUnit": "månader",
+        "productId": "10022",
+        "campaignId": "11"
       }
       }
     }

--- a/data/2016-02-04T14:00:00.000Z/environments.json
+++ b/data/2016-02-04T14:00:00.000Z/environments.json
@@ -1,7 +1,7 @@
 {
   "stage": {
     "payment": {
-      "externalHost": "http://localhost.aftonbladet.se:9000",
+      "externalHost": "http://stage.login.aftonbladet.se",
       "path": "purchase",
       "productQuery": "product_id",
       "campaignQuery": "campaign_id",

--- a/data/2016-02-04T14:00:00.000Z/environments.json
+++ b/data/2016-02-04T14:00:00.000Z/environments.json
@@ -1,67 +1,6 @@
 {
   "stage": {
     "payment": {
-      "externalHost": "http://stage.login.aftonbladet.se",
-      "path": "purchase",
-      "productQuery": "product_id",
-      "campaignQuery": "campaign_id",
-      "offers": {
-        "three-months-monthly": {
-          "months": 3,
-          "price": 149,
-          "unit": "kr/månad",
-          "productId": "200247",
-          "campaignId": "10020"
-        },
-        "six-months-monthly": {
-          "months": 6,
-          "price": 129,
-          "unit": "kr/månad",
-          "productId": "200249",
-          "campaignId": "10020"
-        },
-        "twelve-months-monthly": {
-          "months": 12,
-          "price": 79,
-          "unit": "kr/månad",
-          "productId": "200251",
-          "campaignId": "10020"
-        },
-        "three-months-upfront": {
-          "months": 3,
-          "price": 447,
-          "unit": "kr",
-          "productId": "200248",
-          "campaignId": "10051"
-        },
-        "six-months-upfront": {
-          "months": 6,
-          "price": 774,
-          "unit": "kr",
-          "productId": "200250",
-          "campaignId": "10051"
-        },
-        "twelve-months-upfront": {
-          "months": 12,
-          "price": 948,
-          "unit": "kr",
-          "productId": "200252",
-          "campaignId": "10051"
-        },
-      "special-offer": {
-        "months": 100,
-        "price": 398,
-        "unit": "kr",
-        "offerLength": 6,
-        "lengthUnit": "månader",
-        "productId": "203243",
-        "campaignId": "11036"
-      }
-      }
-    }
-  }
-  "localhost": {
-    "payment": {
       "externalHost": "http://localhost.aftonbladet.se:9000",
       "path": "purchase",
       "productQuery": "product_id",

--- a/data/2016-02-04T14:00:00.000Z/environments.json
+++ b/data/2016-02-04T14:00:00.000Z/environments.json
@@ -60,4 +60,65 @@
       }
     }
   }
+  "localhost": {
+    "payment": {
+      "externalHost": "http://localhost.aftonbladet.se:9000",
+      "path": "purchase",
+      "productQuery": "product_id",
+      "campaignQuery": "campaign_id",
+      "offers": {
+        "three-months-monthly": {
+          "months": 3,
+          "price": 149,
+          "unit": "kr/månad",
+          "productId": "200247",
+          "campaignId": "10020"
+        },
+        "six-months-monthly": {
+          "months": 6,
+          "price": 129,
+          "unit": "kr/månad",
+          "productId": "200249",
+          "campaignId": "10020"
+        },
+        "twelve-months-monthly": {
+          "months": 12,
+          "price": 79,
+          "unit": "kr/månad",
+          "productId": "200251",
+          "campaignId": "10020"
+        },
+        "three-months-upfront": {
+          "months": 3,
+          "price": 447,
+          "unit": "kr",
+          "productId": "200248",
+          "campaignId": "10051"
+        },
+        "six-months-upfront": {
+          "months": 6,
+          "price": 774,
+          "unit": "kr",
+          "productId": "200250",
+          "campaignId": "10051"
+        },
+        "twelve-months-upfront": {
+          "months": 12,
+          "price": 948,
+          "unit": "kr",
+          "productId": "200252",
+          "campaignId": "10051"
+        },
+      "special-offer": {
+        "months": 100,
+        "price": 398,
+        "unit": "kr",
+        "offerLength": 6,
+        "lengthUnit": "månader",
+        "productId": "203243",
+        "campaignId": "11036"
+      }
+      }
+    }
+  }
 }


### PR DESCRIPTION
@annastei or @marekwojtaszek or @rudolf-qwaya 
This update has a working campaign and product configuration in stage/test and localhost.
The current config for stage is broken as it refers to products ids and campaign ids that no-longer exists in the SPiD stage environment.

Note that the new config refers to existing products and campaigns so that one can buy products using the new SPiD flow at stage. However, there are currently only two products and one campaign for Viktklubb in the SPiD stage environment. Hence the somewhat heavy re-use of product ids in the config.
 