### PR TITLE
ABVKC-2548 Removal of VK icons on the bottom of article page

### DIFF
--- a/data/2016-06-07T22:00:00.000Z/containers/article-cta.json
+++ b/data/2016-06-07T22:00:00.000Z/containers/article-cta.json
@@ -8,9 +8,7 @@
     {
       "type": "cta-element",
       "order": "0",
-      "props": {
-        "label": "Håll vikten med oss!"
-      }
+      "props": {}
     }
   ]
 }

--- a/data/2016-06-07T22:00:00.000Z/data.json
+++ b/data/2016-06-07T22:00:00.000Z/data.json
@@ -94,9 +94,7 @@
       "containers": [
         "bmi-calculator",
         "bmi-range-display",
-        "bmi-result-cta",
-        "all-features",
-        "grid-cta"
+        "bmi-result-cta"
       ]
     },
     "memberships": {


### PR DESCRIPTION
This PR removes VK icons from articles and removes `label` for action button on articles.

The latter change is required to disable action button on articles. Appropriate changes needs to be merged to `WeightClub4-Web` to make it fully work first. There is a PR to be merged before this one can be tested: https://github.com/Aftonbladet/WeightClub4-Web/pull/189

Changes in this PR are made agains the most recent campaign that will start on `2016-06-07T22:00:00.000Z`

Ping: @rudolf-qwaya 